### PR TITLE
Ensure nextQuestion executes before finishing trainer session

### DIFF
--- a/components/educa/matematicas/tablas/MultiplicationTablesTrainer.tsx
+++ b/components/educa/matematicas/tablas/MultiplicationTablesTrainer.tsx
@@ -80,16 +80,21 @@ export const MultiplicationTablesTrainer = (props: TablesTrainerProps) => {
 
   // Manejar siguiente pregunta
   const handleNextQuestion = () => {
-    if (isLastQuestion) {
-      if (state.mode === 'quiz') {
-        setCurrentView('results');
-        stopTimer();
-      } else {
-        setCurrentView('menu');
-      }
-    } else {
-      nextQuestion();
+    const wasLastQuestion = isLastQuestion;
+
+    nextQuestion();
+
+    if (!wasLastQuestion) {
+      return;
     }
+
+    if (state.mode === 'quiz') {
+      setCurrentView('results');
+      stopTimer();
+      return;
+    }
+
+    setCurrentView('menu');
   };
 
   // Volver al menú


### PR DESCRIPTION
## Summary
- ensure `handleNextQuestion` always advances through `nextQuestion` before handling completion logic
- gate the navigation updates on the prior last-question flag so quiz results and practice menu routing remain intact

## Testing
- pnpm lint *(fails: pre-existing lint errors across the repository)*
- Manual QA: Completed a practice session in `/matematicas/tablas`, confirmed the Progreso tab displays the new results, and observed console logs with persisted progress data

------
https://chatgpt.com/codex/tasks/task_e_68cc8cc791888327b6a01d59efa47e9e