### PR TITLE
feat: playful styling for math tables panels and stats

### DIFF
--- a/components/educa/matematicas/tablas/ui/Panel.tsx
+++ b/components/educa/matematicas/tablas/ui/Panel.tsx
@@ -4,24 +4,47 @@
 import { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
+type PanelVariant = 'default' | 'playful' | 'success' | 'info';
+
 interface PanelProps {
   children: ReactNode;
   className?: string;
   title?: string;
   description?: string;
+  variant?: PanelVariant;
 }
 
-export const Panel = ({ children, className, title, description }: PanelProps) => {
+const variantStyles: Record<PanelVariant, string> = {
+  default:
+    'bg-white/95 border border-gray-200 rounded-2xl shadow-sm',
+  playful:
+    'bg-white/80 border-4 border-dashed border-sky-200 rounded-3xl shadow-lg backdrop-blur-sm',
+  success:
+    'bg-emerald-50/90 border border-emerald-200 rounded-3xl shadow-md',
+  info:
+    'bg-sky-50/90 border border-sky-200 rounded-3xl shadow-md'
+};
+
+export const Panel = ({
+  children,
+  className,
+  title,
+  description,
+  variant = 'default'
+}: PanelProps) => {
   return (
     <div className={cn(
-      "bg-white rounded-lg border border-gray-200 shadow-sm p-6",
+      'p-6 transition-shadow duration-300',
+      variantStyles[variant],
       className
     )}>
       {title && (
         <div className="mb-4">
-          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <h3 className="text-xl font-semibold text-sky-900">{title}</h3>
           {description && (
-            <p className="text-sm text-gray-600 mt-1">{description}</p>
+            <p className="mt-1 text-sm text-sky-800/90 before:content-['⭐'] before:mr-2 before:text-sky-500">
+              {description}
+            </p>
           )}
         </div>
       )}

--- a/components/educa/matematicas/tablas/ui/ProgressOverview.tsx
+++ b/components/educa/matematicas/tablas/ui/ProgressOverview.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { Panel } from './Panel';
 import { StatCard } from './StatCard';
+import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
@@ -60,11 +61,11 @@ export const ProgressOverview = ({
 
   if (!hasAnyProgress) {
     return (
-      <Panel title="Tu progreso">
-        <div className="text-center py-8 text-gray-500">
+      <Panel variant="playful" title="Tu progreso">
+        <div className="text-center py-8 text-sky-700">
           <div className="text-4xl mb-3">📊</div>
-          <p>Aún no hay datos de progreso.</p>
-          <p className="text-sm mt-1">¡Empezá a practicar para ver tus estadísticas!</p>
+          <p className="font-semibold">Aún no hay datos de progreso.</p>
+          <p className="text-sm mt-1 opacity-80">¡Empezá a practicar para ver tus estadísticas!</p>
           
           {/* Debug info en modo desarrollo */}
           {process.env.NODE_ENV === 'development' && (
@@ -83,7 +84,7 @@ export const ProgressOverview = ({
   return (
     <div className="space-y-6">
       {/* Resumen general */}
-      <Panel title="Resumen general">
+      <Panel variant="playful" title="Resumen general">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <StatCard
             label="Precisión total"
@@ -93,76 +94,79 @@ export const ProgressOverview = ({
           <StatCard
             label="Total correctas"
             value={progress.totalCorrect}
-            color="green"
+            color="teal"
           />
           <StatCard
             label="Total intentos"
             value={progress.totalAttempts}
-            color="blue"
+            color="amber"
           />
           <StatCard
             label="Última actualización"
             value={format(progress.lastUpdated, 'dd/MM', { locale: es })}
-            color="purple"
+            color="pink"
           />
         </div>
       </Panel>
 
       {/* Progreso por tabla */}
-      <Panel title="Progreso por tabla">
+      <Panel variant="playful" title="Progreso por tabla">
         <div className="space-y-3">
           {tableNumbers.map(table => {
             const tableProgress = getTableProgress(table);
             const hasData = tableProgress.totalAttempts > 0;
-            
+
             return (
-              <div 
-                key={table} 
-                className={`p-4 border rounded-lg ${hasData ? 'bg-white' : 'bg-gray-50'}`}
+              <div
+                key={table}
+                className={cn(
+                  'p-4 border rounded-2xl shadow-sm transition-transform duration-200 hover:-translate-y-0.5',
+                  hasData ? 'bg-white/80 border-sky-100' : 'bg-sky-50/80 border-sky-100'
+                )}
               >
                 <div className="flex items-center justify-between mb-2">
-                  <h4 className="font-semibold text-gray-900">
+                  <h4 className="font-semibold text-sky-900">
                     Tabla del {table}
                   </h4>
                   {hasData && (
-                    <Badge 
+                    <Badge
                       variant={tableProgress.accuracy >= 80 ? 'default' : 'secondary'}
-                      className="ml-2"
+                      className="ml-2 bg-white/80 text-sky-800 border border-sky-200"
                     >
                       {tableProgress.accuracy.toFixed(0)}%
                     </Badge>
                   )}
                 </div>
-                
+
                 {hasData ? (
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
                     <div>
-                      <span className="text-gray-500">{i18n.progress.correct}: </span>
+                      <span className="text-sky-700">{i18n.progress.correct}: </span>
                       <span className="font-medium">{tableProgress.correctAnswers}</span>
                     </div>
                     <div>
-                      <span className="text-gray-500">{i18n.progress.attempts}: </span>
+                      <span className="text-sky-700">{i18n.progress.attempts}: </span>
                       <span className="font-medium">{tableProgress.totalAttempts}</span>
                     </div>
                     <div>
-                      <span className="text-gray-500">{i18n.progress.bestStreak}: </span>
+                      <span className="text-sky-700">{i18n.progress.bestStreak}: </span>
                       <span className="font-medium">{tableProgress.bestStreak}</span>
                     </div>
                     <div>
-                      <span className="text-gray-500">{i18n.progress.lastPlayed}: </span>
-                      <span className="font-medium">
+                      <span className="text-sky-700">{i18n.progress.lastPlayed}: </span>
+                      <span className="font-medium text-sky-900">
                         {format(tableProgress.lastPlayedAt, 'dd/MM', { locale: es })}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <p className="text-sm text-gray-500">Sin datos aún</p>
+                  <p className="text-sm text-sky-600">Sin datos aún</p>
                 )}
-                
+
                 {hasData && tableProgress.badges.length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-1">
                     {tableProgress.badges.map(badge => (
-                      <Badge key={badge} variant="outline" className="text-xs">
+                      <Badge key={badge} variant="outline" className="text-xs bg-white/80 border-sky-200 text-sky-800">
                         {badge}
                       </Badge>
                     ))}

--- a/components/educa/matematicas/tablas/ui/QuizResults.tsx
+++ b/components/educa/matematicas/tablas/ui/QuizResults.tsx
@@ -1,7 +1,7 @@
 // components/learning/ui/QuizResults.tsx
 'use client';
 
-import { Panel} from './Panel';
+import { Panel } from './Panel';
 import { StatCard } from './StatCard';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -63,15 +63,15 @@ export const QuizResults = ({
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       {/* Mensaje motivacional */}
-      <Panel className="text-center">
+      <Panel variant="playful" className="text-center">
         <div className="space-y-3">
           <div className="text-4xl">
             {accuracy === 100 ? '🏆' : accuracy >= 80 ? '🎉' : accuracy >= 60 ? '👏' : '💪'}
           </div>
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="text-2xl font-bold text-sky-900">
             {getMotivationalMessage()}
           </h2>
-          <p className="text-gray-600">
+          <p className="text-sky-700">
             Respondiste {correctCount} de {totalCount} preguntas correctamente
           </p>
         </div>
@@ -89,38 +89,38 @@ export const QuizResults = ({
           label="Mejor racha"
           value={bestStreak}
           icon={<Zap className="h-6 w-6" />}
-          color="purple"
+          color="pink"
         />
         <StatCard
           label="Tiempo total"
           value={formatTime(totalTime)}
           icon={<Clock className="h-6 w-6" />}
-          color="blue"
+          color="amber"
         />
         <StatCard
           label="Promedio por pregunta"
           value={formatTime(totalTime / totalCount)}
           icon={<Clock className="h-6 w-6" />}
-          color="blue"
+          color="teal"
         />
       </div>
 
       {/* Progreso visual */}
-      <Panel title="Tu progreso">
+      <Panel variant="playful" title="Tu progreso">
         <div className="space-y-4">
-          <div className="flex justify-between text-sm text-gray-600">
+          <div className="flex justify-between text-sm text-sky-700">
             <span>Respuestas correctas</span>
             <span>{correctCount}/{totalCount}</span>
           </div>
-          <Progress value={(correctCount / totalCount) * 100} className="h-3" />
+          <Progress value={(correctCount / totalCount) * 100} className="h-3 bg-sky-100" />
         </div>
       </Panel>
 
       {/* Desglose por tabla */}
-      <Panel title="Desglose por tabla">
+      <Panel variant="playful" title="Desglose por tabla">
         <div className="space-y-3">
           {result.tablesUsed.map(table => {
-            const tableQuestions = result.questions.filter(q => 
+            const tableQuestions = result.questions.filter(q =>
               q.factor1 === table || q.factor2 === table
             );
             const tableCorrect = tableQuestions.filter(q => q.isCorrect).length;
@@ -128,19 +128,22 @@ export const QuizResults = ({
             const tableAccuracy = tableTotal > 0 ? (tableCorrect / tableTotal) * 100 : 0;
 
             return (
-              <div key={table} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+              <div
+                key={table}
+                className="flex items-center justify-between p-3 rounded-2xl bg-sky-50/80 border border-sky-100"
+              >
                 <div className="flex items-center space-x-3">
-                  <Badge variant="outline" className="font-semibold">
+                  <Badge variant="outline" className="font-semibold bg-white/80 border-sky-200 text-sky-800">
                     Tabla del {table}
                   </Badge>
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-sky-700">
                     {tableCorrect}/{tableTotal}
                   </span>
                 </div>
                 <div className="flex items-center space-x-2">
                   <span className={`text-sm font-medium ${
-                    tableAccuracy >= 80 ? 'text-green-600' : 
-                    tableAccuracy >= 60 ? 'text-blue-600' : 
+                    tableAccuracy >= 80 ? 'text-green-600' :
+                    tableAccuracy >= 60 ? 'text-blue-600' :
                     'text-yellow-600'
                   }`}>
                     {tableAccuracy.toFixed(0)}%
@@ -154,12 +157,15 @@ export const QuizResults = ({
 
       {/* Revisión de respuestas incorrectas */}
       {result.questions.some(q => !q.isCorrect) && (
-        <Panel title="Respuestas para revisar">
+        <Panel variant="playful" title="Respuestas para revisar">
           <div className="space-y-2">
             {result.questions
               .filter(q => !q.isCorrect)
               .map((question) => (
-                <div key={question.id} className="flex items-center justify-between p-2 bg-red-50 border border-red-200 rounded">
+                <div
+                  key={question.id}
+                  className="flex items-center justify-between p-2 bg-rose-50/80 border border-rose-200 rounded-2xl"
+                >
                   <span className="text-sm">
                     {question.factor1} × {question.factor2} = {question.answer}
                   </span>

--- a/components/educa/matematicas/tablas/ui/StatCard.tsx
+++ b/components/educa/matematicas/tablas/ui/StatCard.tsx
@@ -2,42 +2,59 @@
 import { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
+type StatCardColor =
+  | 'blue'
+  | 'green'
+  | 'yellow'
+  | 'red'
+  | 'purple'
+  | 'amber'
+  | 'pink'
+  | 'teal';
+
 interface StatCardProps {
   label: string;
   value: string | number;
   icon?: ReactNode;
-  color?: 'blue' | 'green' | 'yellow' | 'red' | 'purple';
+  color?: StatCardColor;
   className?: string;
 }
 
-export const StatCard = ({ 
-  label, 
-  value, 
-  icon, 
-  color = 'blue', 
-  className 
+export const StatCard = ({
+  label,
+  value,
+  icon,
+  color = 'blue',
+  className
 }: StatCardProps) => {
-  const colorClasses = {
-    blue: 'bg-blue-50 text-blue-700 border-blue-200',
-    green: 'bg-green-50 text-green-700 border-green-200',
-    yellow: 'bg-yellow-50 text-yellow-700 border-yellow-200',
-    red: 'bg-red-50 text-red-700 border-red-200',
-    purple: 'bg-purple-50 text-purple-700 border-purple-200'
+  const colorClasses: Record<StatCardColor, string> = {
+    blue: 'bg-sky-100 text-sky-900 border-sky-200',
+    green: 'bg-emerald-100 text-emerald-900 border-emerald-200',
+    yellow: 'bg-yellow-100 text-yellow-900 border-yellow-200',
+    red: 'bg-rose-100 text-rose-900 border-rose-200',
+    purple: 'bg-purple-100 text-purple-900 border-purple-200',
+    amber: 'bg-amber-100 text-amber-900 border-amber-200',
+    pink: 'bg-pink-100 text-pink-900 border-pink-200',
+    teal: 'bg-teal-100 text-teal-900 border-teal-200'
   };
 
   return (
     <div className={cn(
-      "border rounded-lg p-4 text-center",
+      'border rounded-3xl p-6 text-center shadow-md shadow-sky-200/70 transition-transform duration-200 hover:-translate-y-0.5',
       colorClasses[color],
       className
     )}>
       {icon && (
-        <div className="flex justify-center mb-2">
-          {icon}
+        <div className="flex justify-center mb-3">
+          <div className="inline-flex items-center justify-center bg-white rounded-full p-2 shadow-sm">
+            {icon}
+          </div>
         </div>
       )}
-      <div className="text-2xl font-bold mb-1">{value}</div>
-      <div className="text-sm font-medium">{label}</div>
+      <div className="text-3xl font-black mb-1 text-current">{value}</div>
+      <div className="text-sm font-semibold tracking-wide uppercase text-current opacity-80">
+        {label}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add variant-driven styling to the math tables Panel component with colorful headings and optional playful theme
- refresh StatCard visuals with rounded corners, centered icon badges, and pastel palettes
- apply the playful theme to QuizResults and ProgressOverview so the child components use the new variants consistently

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3acf08988327a573d4e3990353c9