### PR TITLE
feat: refresh tablas trainer ui styling

### DIFF
--- a/components/educa/matematicas/tablas/ui/PracticeSettings.tsx
+++ b/components/educa/matematicas/tablas/ui/PracticeSettings.tsx
@@ -6,6 +6,22 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import type { PracticeSettings as PracticeSettingsType } from '../types';
 import { Panel } from './Panel';
 import { Button } from '@/components/ui/button';
+import {
+  Smile,
+  Sparkles,
+  Star,
+  Sun,
+  Rainbow,
+  Heart,
+  Flower2,
+  PartyPopper,
+  MoonStar,
+  WandSparkles,
+  Shuffle,
+  Lightbulb,
+  Check
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface PracticeSettingsProps {
   settings: PracticeSettingsType;
@@ -32,9 +48,22 @@ export const PracticeSettingsComponent = ({
   mode
 }: PracticeSettingsProps) => {
   const tableNumbers = Array.from(
-    { length: maxTable - minTable + 1 }, 
+    { length: maxTable - minTable + 1 },
     (_, i) => minTable + i
   );
+
+  const tableIcons = [
+    Smile,
+    Sparkles,
+    Star,
+    Sun,
+    Rainbow,
+    Heart,
+    Flower2,
+    PartyPopper,
+    MoonStar,
+    WandSparkles
+  ];
 
   const handleTableToggle = (table: number, checked: boolean) => {
     if (checked) {
@@ -59,23 +88,47 @@ export const PracticeSettingsComponent = ({
             {i18n.selectTables}
           </Label>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-            {tableNumbers.map(table => (
-              <div key={table} className="flex items-center space-x-2">
-                <Checkbox
-                  id={`table-${table}`}
-                  checked={settings.selectedTables.includes(table)}
-                  onCheckedChange={(checked) => 
-                    handleTableToggle(table, checked as boolean)
-                  }
-                />
-                <Label 
+            {tableNumbers.map((table, index) => {
+              const Icon = tableIcons[index % tableIcons.length];
+              const isSelected = settings.selectedTables.includes(table);
+
+              return (
+                <label
+                  key={table}
                   htmlFor={`table-${table}`}
-                  className="text-sm font-medium cursor-pointer"
+                  className={cn(
+                    'group relative flex items-center justify-between gap-3 rounded-full border border-transparent bg-white/80 px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-pink-300 dark:bg-slate-900/60 dark:text-slate-100',
+                    isSelected
+                      ? 'ring-2 ring-offset-2 ring-pink-300 dark:ring-pink-400 dark:ring-offset-slate-950'
+                      : 'ring-1 ring-white/60 dark:ring-white/10'
+                  )}
                 >
-                  Tabla del {table}
-                </Label>
-              </div>
-            ))}
+                  <Checkbox
+                    id={`table-${table}`}
+                    checked={isSelected}
+                    onCheckedChange={(checked) =>
+                      handleTableToggle(table, checked as boolean)
+                    }
+                    className="sr-only"
+                  />
+                  <span className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-pink-200 via-white to-sky-200 text-pink-600 shadow-inner dark:from-pink-500/60 dark:via-slate-900 dark:to-sky-500/60">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <span>Tabla del {table}</span>
+                  </span>
+                  <span
+                    className={cn(
+                      'flex h-6 w-6 items-center justify-center rounded-full bg-pink-200/80 text-pink-600 transition-opacity dark:bg-pink-500/40 dark:text-pink-100',
+                      isSelected ? 'opacity-100' : 'opacity-0'
+                    )}
+                    aria-hidden="true"
+                  >
+                    <Check className="h-4 w-4" />
+                  </span>
+                </label>
+              );
+            })}
           </div>
         </div>
 
@@ -104,40 +157,68 @@ export const PracticeSettingsComponent = ({
         </div>
 
         {/* Opciones adicionales */}
-        <div className="space-y-3">
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="random-order"
-              checked={settings.randomOrder}
-              onCheckedChange={(checked) => 
-                onSettingsChange({ randomOrder: checked as boolean })
-              }
-            />
-            <Label htmlFor="random-order" className="text-sm">
-              Orden aleatorio
-            </Label>
-          </div>
-
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="show-hints"
-              checked={settings.showHints}
-              onCheckedChange={(checked) => 
-                onSettingsChange({ showHints: checked as boolean })
-              }
-            />
-            <Label htmlFor="show-hints" className="text-sm">
-              Permitir pistas
-            </Label>
-          </div>
+        <div className="flex flex-wrap gap-3">
+          {[{
+            id: 'random-order',
+            label: 'Orden aleatorio',
+            description: 'Mezcla las preguntas',
+            checked: settings.randomOrder,
+            onChange: (checked: boolean) => onSettingsChange({ randomOrder: checked }),
+            Icon: Shuffle
+          }, {
+            id: 'show-hints',
+            label: 'Permitir pistas',
+            description: 'Activa ayudas visuales',
+            checked: settings.showHints,
+            onChange: (checked: boolean) => onSettingsChange({ showHints: checked }),
+            Icon: Lightbulb
+          }].map(option => (
+            <label
+              key={option.id}
+              htmlFor={option.id}
+              className={cn(
+                'flex min-w-[220px] flex-1 cursor-pointer items-center justify-between gap-3 rounded-full border border-transparent bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-pink-300 dark:bg-slate-900/60 dark:text-slate-100',
+                option.checked
+                  ? 'ring-2 ring-offset-2 ring-pink-300 dark:ring-pink-400 dark:ring-offset-slate-950'
+                  : 'ring-1 ring-white/60 dark:ring-white/10'
+              )}
+            >
+              <Checkbox
+                id={option.id}
+                checked={option.checked}
+                onCheckedChange={(checked) => option.onChange(checked as boolean)}
+                className="sr-only"
+              />
+              <span className="flex items-center gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-amber-200 via-white to-rose-200 text-amber-600 shadow-inner dark:from-amber-500/50 dark:via-slate-900 dark:to-rose-500/50">
+                  <option.Icon className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <span className="text-left">
+                  <span className="block font-semibold">{option.label}</span>
+                  <span className="block text-xs text-slate-500 dark:text-slate-300">{option.description}</span>
+                </span>
+              </span>
+              <span
+                className={cn(
+                  'flex h-6 w-6 items-center justify-center rounded-full bg-pink-200/80 text-pink-600 transition-opacity dark:bg-pink-500/40 dark:text-pink-100',
+                  option.checked ? 'opacity-100' : 'opacity-0'
+                )}
+                aria-hidden="true"
+              >
+                <Check className="h-4 w-4" />
+              </span>
+            </label>
+          ))}
         </div>
 
         {/* Resumen de selección */}
         {settings.selectedTables.length > 0 && (
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <div className="text-sm text-blue-800">
-              <strong>Seleccionaste:</strong> Tablas del {settings.selectedTables.join(', ')} 
-              ({settings.questionCount} preguntas)
+          <div className="rounded-3xl border-0 bg-gradient-to-r from-pink-50 via-rose-50 to-amber-50 p-4 text-sm text-rose-700 shadow-inner dark:from-rose-900/40 dark:via-rose-900/30 dark:to-amber-900/30 dark:text-rose-100">
+            <div className="font-semibold">
+              Seleccionaste: Tablas del {settings.selectedTables.join(', ')}
+            </div>
+            <div className="text-xs text-rose-500 dark:text-rose-200">
+              {settings.questionCount} preguntas preparadas
             </div>
           </div>
         )}

--- a/components/educa/matematicas/tablas/ui/ProgressOverview.tsx
+++ b/components/educa/matematicas/tablas/ui/ProgressOverview.tsx
@@ -6,6 +6,8 @@ import { StatCard } from './StatCard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import { Sparkles, BarChart3, Crown, Target } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { ProgressSnapshot } from '../types';
 
 interface ProgressOverviewProps {
@@ -53,28 +55,15 @@ export const ProgressOverview = ({
 
   const hasAnyProgress = progress.totalAttempts > 0;
 
-  // Debug logging
-  console.log('ProgressOverview - Progreso recibido:', progress);
-  console.log('ProgressOverview - ¿Hay progreso?:', hasAnyProgress);
-  console.log('ProgressOverview - Tablas disponibles:', Object.keys(progress.tables || {}));
-
   if (!hasAnyProgress) {
     return (
-      <Panel title="Tu progreso">
-        <div className="text-center py-8 text-gray-500">
-          <div className="text-4xl mb-3">📊</div>
-          <p>Aún no hay datos de progreso.</p>
-          <p className="text-sm mt-1">¡Empezá a practicar para ver tus estadísticas!</p>
-          
-          {/* Debug info en modo desarrollo */}
-          {process.env.NODE_ENV === 'development' && (
-            <details className="mt-4 text-left">
-              <summary className="cursor-pointer">Debug: Datos de progreso</summary>
-              <pre className="text-xs bg-gray-100 p-2 rounded mt-2 overflow-auto">
-                {JSON.stringify(progress, null, 2)}
-              </pre>
-            </details>
-          )}
+      <Panel className="rounded-3xl border-0 bg-gradient-to-br from-sky-100 via-white to-emerald-100 p-10 text-center shadow-xl dark:from-slate-900 dark:via-slate-950 dark:to-emerald-950">
+        <div className="flex flex-col items-center gap-4 text-slate-700 dark:text-slate-200">
+          <Sparkles className="h-12 w-12 text-emerald-500" />
+          <p className="text-xl font-semibold">Aún no hay datos de progreso.</p>
+          <p className="max-w-md text-sm text-slate-600 dark:text-slate-300">
+            Comenzá una práctica para desbloquear estadísticas y medallas.
+          </p>
         </div>
       </Panel>
     );
@@ -83,91 +72,122 @@ export const ProgressOverview = ({
   return (
     <div className="space-y-6">
       {/* Resumen general */}
-      <Panel title="Resumen general">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <Panel
+        title="Resumen general"
+        className="rounded-3xl border-0 bg-gradient-to-br from-sky-100 via-white to-emerald-100 shadow-xl dark:from-slate-900 dark:via-slate-950 dark:to-emerald-950"
+      >
+        <div className="grid gap-4 md:grid-cols-4">
           <StatCard
             label="Precisión total"
             value={`${progress.overallAccuracy.toFixed(1)}%`}
             color={progress.overallAccuracy >= 80 ? 'green' : progress.overallAccuracy >= 60 ? 'blue' : 'yellow'}
+            icon={<Target className="h-6 w-6" />}
+            className="rounded-3xl border-0 bg-white/80 p-6 text-slate-800 shadow-lg backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
           />
           <StatCard
             label="Total correctas"
             value={progress.totalCorrect}
             color="green"
+            icon={<Sparkles className="h-6 w-6" />}
+            className="rounded-3xl border-0 bg-white/80 p-6 text-slate-800 shadow-lg backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
           />
           <StatCard
             label="Total intentos"
             value={progress.totalAttempts}
             color="blue"
+            icon={<BarChart3 className="h-6 w-6" />}
+            className="rounded-3xl border-0 bg-white/80 p-6 text-slate-800 shadow-lg backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
           />
           <StatCard
             label="Última actualización"
             value={format(progress.lastUpdated, 'dd/MM', { locale: es })}
             color="purple"
+            icon={<Crown className="h-6 w-6" />}
+            className="rounded-3xl border-0 bg-white/80 p-6 text-slate-800 shadow-lg backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
           />
         </div>
       </Panel>
 
       {/* Progreso por tabla */}
-      <Panel title="Progreso por tabla">
-        <div className="space-y-3">
+      <Panel
+        title="Progreso por tabla"
+        className="rounded-3xl border-0 bg-white/90 shadow-xl backdrop-blur dark:bg-slate-950/60"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
           {tableNumbers.map(table => {
             const tableProgress = getTableProgress(table);
             const hasData = tableProgress.totalAttempts > 0;
-            
+
             return (
-              <div 
-                key={table} 
-                className={`p-4 border rounded-lg ${hasData ? 'bg-white' : 'bg-gray-50'}`}
+              <div
+                key={table}
+                className={cn(
+                  'relative overflow-hidden rounded-3xl p-5 text-slate-800 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:text-slate-100',
+                  hasData
+                    ? 'bg-gradient-to-r from-sky-200/80 via-emerald-200/70 to-emerald-100/70 dark:from-sky-900/40 dark:via-emerald-900/40 dark:to-emerald-900/30'
+                    : 'bg-gradient-to-r from-slate-100/80 to-slate-200/70 dark:from-slate-900/50 dark:to-slate-800/60'
+                )}
               >
-                <div className="flex items-center justify-between mb-2">
-                  <h4 className="font-semibold text-gray-900">
-                    Tabla del {table}
-                  </h4>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/80 text-sky-500 shadow-inner dark:bg-slate-900/60 dark:text-sky-300">
+                      <Sparkles className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <div>
+                      <h4 className="text-lg font-semibold">Tabla del {table}</h4>
+                      <p className="text-xs text-slate-600 dark:text-slate-300">
+                        {hasData ? `${tableProgress.correctAnswers} aciertos de ${tableProgress.totalAttempts} intentos` : 'Sin datos aún'}
+                      </p>
+                    </div>
+                  </div>
                   {hasData && (
-                    <Badge 
-                      variant={tableProgress.accuracy >= 80 ? 'default' : 'secondary'}
-                      className="ml-2"
-                    >
+                    <Badge className="rounded-full border-0 bg-emerald-500/90 px-3 py-1 text-sm font-semibold text-white shadow-sm">
                       {tableProgress.accuracy.toFixed(0)}%
                     </Badge>
                   )}
                 </div>
-                
-                {hasData ? (
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-                    <div>
-                      <span className="text-gray-500">{i18n.progress.correct}: </span>
-                      <span className="font-medium">{tableProgress.correctAnswers}</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-500">{i18n.progress.attempts}: </span>
-                      <span className="font-medium">{tableProgress.totalAttempts}</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-500">{i18n.progress.bestStreak}: </span>
-                      <span className="font-medium">{tableProgress.bestStreak}</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-500">{i18n.progress.lastPlayed}: </span>
-                      <span className="font-medium">
-                        {format(tableProgress.lastPlayedAt, 'dd/MM', { locale: es })}
+
+                <div className="mt-4 space-y-4">
+                  <div className="h-3 w-full overflow-hidden rounded-full bg-white/60 dark:bg-slate-900/60">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-sky-500 via-teal-400 to-emerald-500 transition-all"
+                      style={{ width: `${hasData ? tableProgress.accuracy : 5}%` }}
+                      aria-hidden="true"
+                    />
+                  </div>
+
+                  {hasData ? (
+                    <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700 dark:text-slate-200">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 shadow-sm dark:bg-slate-900/60">
+                        <Sparkles className="h-3.5 w-3.5" /> {i18n.progress.correct}: {tableProgress.correctAnswers}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 shadow-sm dark:bg-slate-900/60">
+                        <BarChart3 className="h-3.5 w-3.5" /> {i18n.progress.attempts}: {tableProgress.totalAttempts}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 shadow-sm dark:bg-slate-900/60">
+                        <Crown className="h-3.5 w-3.5" /> {i18n.progress.bestStreak}: {tableProgress.bestStreak}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 shadow-sm dark:bg-slate-900/60">
+                        <Target className="h-3.5 w-3.5" /> {i18n.progress.lastPlayed}: {format(tableProgress.lastPlayedAt, 'dd/MM', { locale: es })}
                       </span>
                     </div>
-                  </div>
-                ) : (
-                  <p className="text-sm text-gray-500">Sin datos aún</p>
-                )}
-                
-                {hasData && tableProgress.badges.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {tableProgress.badges.map(badge => (
-                      <Badge key={badge} variant="outline" className="text-xs">
-                        {badge}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
+                  ) : (
+                    <p className="text-sm text-slate-600 dark:text-slate-300">Sin datos aún</p>
+                  )}
+
+                  {hasData && tableProgress.badges.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {tableProgress.badges.map(badge => (
+                        <Badge
+                          key={badge}
+                          className="rounded-full border-0 bg-white/80 px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm dark:bg-slate-900/60 dark:text-slate-100"
+                        >
+                          {badge}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
             );
           })}
@@ -178,7 +198,11 @@ export const ProgressOverview = ({
       <div className="flex justify-end">
         <AlertDialog>
           <AlertDialogTrigger asChild>
-            <Button variant="outline" size="sm" className="text-red-600 hover:text-red-700">
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-full border-2 border-rose-200 bg-white/80 text-rose-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-300 dark:border-rose-500/40 dark:bg-slate-900/70 dark:text-rose-200"
+            >
               {i18n.resetProgress}
             </Button>
           </AlertDialogTrigger>

--- a/components/educa/matematicas/tablas/ui/QuestionCard.tsx
+++ b/components/educa/matematicas/tablas/ui/QuestionCard.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Panel } from './Panel';
-import { Lightbulb, CheckCircle, XCircle } from 'lucide-react';
+import { Lightbulb, CheckCircle, XCircle, Sparkles } from 'lucide-react';
 import type { Question } from '../types';
 import { formatHint } from '../i18n';
 
@@ -72,26 +72,33 @@ export const QuestionCard = ({
   };
 
   return (
-    <Panel className="max-w-md mx-auto">
-      <div className="text-center space-y-6">
+    <Panel className="mx-auto max-w-3xl border-0 bg-gradient-to-br from-indigo-50 via-white to-sky-100 p-10 shadow-2xl dark:from-slate-900 dark:via-slate-950 dark:to-indigo-950">
+      <div className="mx-auto flex max-w-2xl flex-col items-center gap-8 rounded-[36px] border-4 border-indigo-100 bg-white/90 p-8 text-center shadow-xl backdrop-blur-sm dark:border-indigo-500/40 dark:bg-slate-950/70">
         {/* Pregunta */}
-        <div className="space-y-2">
-          <div className="text-4xl font-bold text-gray-900">
-            {question.factor1} × {question.factor2} = ?
+        <div className="space-y-4">
+          <div className="text-sm font-semibold uppercase tracking-[0.3em] text-indigo-400 dark:text-indigo-200">
+            Desafío actual
           </div>
-          
+          <div className="text-6xl font-black text-indigo-900 drop-shadow-sm dark:text-indigo-100">
+            {question.factor1} × {question.factor2}
+            <span className="block text-5xl font-black text-indigo-600/80 dark:text-indigo-300">= ?</span>
+          </div>
+          <div className="text-base font-medium text-indigo-500/90 dark:text-indigo-200/90">
+            ¿Cuál es el resultado correcto?
+          </div>
+
           {/* Feedback visual */}
           {isAnswered && (
-            <div className="flex items-center justify-center space-x-2">
+            <div className="flex items-center justify-center gap-3 text-lg">
               {question.isCorrect ? (
                 <>
-                  <CheckCircle className="h-6 w-6 text-green-500" />
-                  <span className="text-green-700 font-medium">{i18n.correct}</span>
+                  <CheckCircle className="h-7 w-7 text-emerald-500" />
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-300">{i18n.correct}</span>
                 </>
               ) : (
                 <>
-                  <XCircle className="h-6 w-6 text-red-500" />
-                  <span className="text-red-700 font-medium">
+                  <XCircle className="h-7 w-7 text-rose-500" />
+                  <span className="font-semibold text-rose-600 dark:text-rose-300">
                     {i18n.incorrect} - La respuesta es {question.answer}
                   </span>
                 </>
@@ -102,11 +109,11 @@ export const QuestionCard = ({
 
         {/* Input y controles */}
         {!isAnswered ? (
-          <div className="space-y-4">
-            <div>
-              <label 
-                htmlFor="answer-input" 
-                className="block text-sm font-medium text-gray-700 mb-2"
+          <div className="flex w-full flex-col gap-6">
+            <div className="w-full text-left">
+              <label
+                htmlFor="answer-input"
+                className="mb-2 block text-sm font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-200"
               >
                 {i18n.yourAnswer}
               </label>
@@ -117,17 +124,17 @@ export const QuestionCard = ({
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 onKeyPress={handleKeyPress}
-                className="text-center text-lg"
+                className="w-full rounded-2xl border-4 border-dashed border-indigo-200/80 bg-white/80 px-6 py-5 text-center text-3xl font-semibold text-indigo-900 shadow-inner transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-indigo-500/40 dark:bg-slate-900/70 dark:text-indigo-100"
                 placeholder="?"
                 aria-describedby={showHint ? "hint-text" : undefined}
               />
             </div>
 
-            <div className="flex flex-col space-y-3">
+            <div className="flex w-full flex-col gap-3">
               <Button
                 onClick={handleSubmit}
                 disabled={!canSubmit || !inputValue.trim()}
-                className="w-full"
+                className="w-full rounded-2xl bg-indigo-500 text-lg font-semibold text-white shadow-lg transition-transform hover:-translate-y-0.5 hover:bg-indigo-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
                 size="lg"
               >
                 {i18n.submit}
@@ -136,10 +143,10 @@ export const QuestionCard = ({
               <Button
                 variant="outline"
                 onClick={onToggleHint}
-                className="w-full"
+                className="w-full rounded-2xl border-2 border-indigo-200/60 bg-white/70 text-indigo-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 dark:border-indigo-500/30 dark:bg-slate-900/60 dark:text-indigo-200"
                 size="sm"
               >
-                <Lightbulb className="h-4 w-4 mr-2" />
+                <Lightbulb className="mr-2 h-4 w-4" />
                 {showHint ? i18n.hideHint : i18n.showHint}
               </Button>
             </div>
@@ -147,7 +154,7 @@ export const QuestionCard = ({
         ) : (
           <Button
             onClick={onNext}
-            className="w-full"
+            className="w-full rounded-2xl bg-emerald-500 text-lg font-semibold text-white shadow-lg transition-transform hover:-translate-y-0.5 hover:bg-emerald-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
             size="lg"
           >
             {i18n.next}
@@ -156,22 +163,28 @@ export const QuestionCard = ({
 
         {/* Pista */}
         {showHint && !isAnswered && (
-          <div 
+          <div
             id="hint-text"
-            className="bg-blue-50 border border-blue-200 rounded-lg p-3"
+            className="relative mx-auto max-w-md rounded-3xl bg-amber-100/90 p-5 text-left text-amber-900 shadow-lg before:absolute before:-bottom-6 before:left-16 before:h-0 before:w-0 before:-translate-x-3 before:border-[14px] before:border-transparent before:border-t-amber-100/90 dark:bg-amber-500/40 dark:text-amber-50 dark:before:border-t-amber-500/40"
             role="region"
             aria-label="Pista"
           >
-            <div className="text-blue-800 text-sm">
-              💡 {getHintText()}
+            <div className="flex items-start gap-3 text-sm leading-relaxed">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-200/80 text-amber-700 shadow-inner dark:bg-amber-500/60 dark:text-amber-100">
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <span>{getHintText()}</span>
             </div>
           </div>
         )}
 
         {/* Información de respuesta del usuario */}
         {isAnswered && question.userAnswer !== undefined && (
-          <div className="text-sm text-gray-600">
-            Tu respuesta: <Badge variant="outline">{question.userAnswer}</Badge>
+          <div className="text-sm text-indigo-700 dark:text-indigo-200">
+            Tu respuesta:
+            <Badge variant="outline" className="ml-2 rounded-full border-indigo-200 bg-indigo-50/80 px-3 py-1 text-indigo-700 dark:border-indigo-500/40 dark:bg-indigo-900/40 dark:text-indigo-200">
+              {question.userAnswer}
+            </Badge>
           </div>
         )}
       </div>

--- a/components/educa/matematicas/tablas/ui/QuizResults.tsx
+++ b/components/educa/matematicas/tablas/ui/QuizResults.tsx
@@ -6,7 +6,7 @@ import { StatCard } from './StatCard';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { Target, Clock, Zap, RotateCcw, ArrowRight } from 'lucide-react';
+import { Target, Clock, Zap, RotateCcw, ArrowRight, Stars, Sparkles, Trophy } from 'lucide-react';
 import type { QuizResult } from '../types';
 
 interface QuizResultsProps {
@@ -61,66 +61,86 @@ export const QuizResults = ({
   };
 
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
+    <div className="mx-auto max-w-3xl space-y-8">
       {/* Mensaje motivacional */}
-      <Panel className="text-center">
-        <div className="space-y-3">
-          <div className="text-4xl">
-            {accuracy === 100 ? '🏆' : accuracy >= 80 ? '🎉' : accuracy >= 60 ? '👏' : '💪'}
-          </div>
-          <h2 className="text-2xl font-bold text-gray-900">
+      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-fuchsia-200 via-rose-100 to-amber-100 p-8 shadow-2xl dark:from-fuchsia-900/80 dark:via-rose-900/70 dark:to-amber-900/60">
+        <span className="absolute -top-6 left-8 text-rose-300/70 dark:text-rose-500/60">
+          <Stars className="h-16 w-16 animate-pulse" />
+        </span>
+        <span className="absolute top-6 right-6 text-amber-300/70 dark:text-amber-400/60">
+          <Sparkles className="h-10 w-10 animate-bounce" />
+        </span>
+        <span className="absolute bottom-4 left-1/3 text-fuchsia-300/70 dark:text-fuchsia-500/60">
+          <Sparkles className="h-8 w-8 animate-pulse delay-200" />
+        </span>
+        <div className="relative z-10 flex flex-col gap-3 text-rose-900 dark:text-rose-50">
+          <div className="flex items-center gap-3 text-4xl font-black">
+            <Trophy className="h-10 w-10 text-amber-500 drop-shadow" />
             {getMotivationalMessage()}
-          </h2>
-          <p className="text-gray-600">
-            Respondiste {correctCount} de {totalCount} preguntas correctamente
+          </div>
+          <p className="max-w-xl text-lg text-rose-700/90 dark:text-rose-100/90">
+            Respondiste <strong>{correctCount}</strong> de <strong>{totalCount}</strong> preguntas correctamente. ¡Seguí brillando!
           </p>
         </div>
-      </Panel>
+      </div>
 
       {/* Estadísticas principales */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <StatCard
           label={i18n.accuracy}
           value={`${accuracy.toFixed(1)}%`}
           icon={<Target className="h-6 w-6" />}
           color={getAccuracyColor()}
+          className="rounded-3xl border-0 bg-white/85 p-6 text-slate-800 shadow-xl backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
         />
         <StatCard
           label="Mejor racha"
           value={bestStreak}
           icon={<Zap className="h-6 w-6" />}
           color="purple"
+          className="rounded-3xl border-0 bg-white/85 p-6 text-slate-800 shadow-xl backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
         />
         <StatCard
           label="Tiempo total"
           value={formatTime(totalTime)}
           icon={<Clock className="h-6 w-6" />}
           color="blue"
+          className="rounded-3xl border-0 bg-white/85 p-6 text-slate-800 shadow-xl backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
         />
         <StatCard
           label="Promedio por pregunta"
           value={formatTime(totalTime / totalCount)}
           icon={<Clock className="h-6 w-6" />}
           color="blue"
+          className="rounded-3xl border-0 bg-white/85 p-6 text-slate-800 shadow-xl backdrop-blur dark:bg-slate-900/70 dark:text-slate-100"
         />
       </div>
 
       {/* Progreso visual */}
-      <Panel title="Tu progreso">
+      <Panel
+        title="Tu progreso"
+        className="rounded-3xl border-0 bg-white/80 shadow-xl backdrop-blur dark:bg-slate-900/70"
+      >
         <div className="space-y-4">
-          <div className="flex justify-between text-sm text-gray-600">
+          <div className="flex justify-between text-sm text-slate-600 dark:text-slate-300">
             <span>Respuestas correctas</span>
             <span>{correctCount}/{totalCount}</span>
           </div>
-          <Progress value={(correctCount / totalCount) * 100} className="h-3" />
+          <Progress
+            value={(correctCount / totalCount) * 100}
+            className="h-4 overflow-hidden bg-white/60 dark:bg-slate-800/80"
+          />
         </div>
       </Panel>
 
       {/* Desglose por tabla */}
-      <Panel title="Desglose por tabla">
-        <div className="space-y-3">
+      <Panel
+        title="Desglose por tabla"
+        className="rounded-3xl border-0 bg-white/80 shadow-xl backdrop-blur dark:bg-slate-900/70"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
           {result.tablesUsed.map(table => {
-            const tableQuestions = result.questions.filter(q => 
+            const tableQuestions = result.questions.filter(q =>
               q.factor1 === table || q.factor2 === table
             );
             const tableCorrect = tableQuestions.filter(q => q.isCorrect).length;
@@ -128,23 +148,30 @@ export const QuizResults = ({
             const tableAccuracy = tableTotal > 0 ? (tableCorrect / tableTotal) * 100 : 0;
 
             return (
-              <div key={table} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                <div className="flex items-center space-x-3">
-                  <Badge variant="outline" className="font-semibold">
-                    Tabla del {table}
-                  </Badge>
-                  <span className="text-sm text-gray-600">
-                    {tableCorrect}/{tableTotal}
-                  </span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <span className={`text-sm font-medium ${
-                    tableAccuracy >= 80 ? 'text-green-600' : 
-                    tableAccuracy >= 60 ? 'text-blue-600' : 
-                    'text-yellow-600'
-                  }`}>
+              <div
+                key={table}
+                className="flex flex-col gap-4 rounded-3xl bg-white p-5 shadow-lg ring-1 ring-white/60 transition hover:-translate-y-1 hover:shadow-xl dark:bg-slate-950/60 dark:ring-slate-800"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-rose-200 to-amber-200 text-rose-700 shadow-inner dark:from-rose-500/50 dark:to-amber-500/40 dark:text-rose-100">
+                      <Sparkles className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <div>
+                      <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">Tabla del {table}</p>
+                      <p className="text-xs text-slate-500 dark:text-slate-300">{tableCorrect} de {tableTotal} correctas</p>
+                    </div>
+                  </div>
+                  <Badge className="rounded-full border-0 bg-indigo-500/90 px-3 py-1 text-sm font-semibold text-white shadow-sm">
                     {tableAccuracy.toFixed(0)}%
-                  </span>
+                  </Badge>
+                </div>
+                <div className="h-3 w-full rounded-full bg-indigo-100/80 dark:bg-indigo-900/60">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-emerald-400 transition-all dark:from-indigo-500 dark:via-sky-500 dark:to-emerald-500"
+                    style={{ width: `${tableAccuracy}%` }}
+                    aria-hidden="true"
+                  />
                 </div>
               </div>
             );
@@ -154,17 +181,28 @@ export const QuizResults = ({
 
       {/* Revisión de respuestas incorrectas */}
       {result.questions.some(q => !q.isCorrect) && (
-        <Panel title="Respuestas para revisar">
-          <div className="space-y-2">
+        <Panel
+          title="Respuestas para revisar"
+          className="rounded-3xl border-0 bg-white/80 shadow-xl backdrop-blur dark:bg-slate-900/70"
+        >
+          <div className="grid gap-3">
             {result.questions
               .filter(q => !q.isCorrect)
               .map((question) => (
-                <div key={question.id} className="flex items-center justify-between p-2 bg-red-50 border border-red-200 rounded">
-                  <span className="text-sm">
-                    {question.factor1} × {question.factor2} = {question.answer}
+                <div
+                  key={question.id}
+                  className="flex items-start gap-4 rounded-3xl bg-rose-100/90 p-4 text-rose-800 shadow-md transition hover:-translate-y-0.5 dark:bg-rose-900/60 dark:text-rose-100"
+                >
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/80 text-rose-400 shadow-inner dark:bg-rose-900/50 dark:text-rose-200">
+                    <Sparkles className="h-5 w-5" aria-hidden="true" />
                   </span>
-                  <div className="text-xs text-red-600">
-                    Tu respuesta: {question.userAnswer}
+                  <div className="space-y-1 text-sm">
+                    <p className="font-semibold">
+                      {question.factor1} × {question.factor2} = {question.answer}
+                    </p>
+                    <p className="text-xs text-rose-500 dark:text-rose-200">
+                      Tu respuesta: {question.userAnswer}
+                    </p>
                   </div>
                 </div>
               ))}
@@ -177,7 +215,7 @@ export const QuizResults = ({
         <Button
           onClick={onRestart}
           variant="outline"
-          className="flex-1"
+          className="flex-1 rounded-2xl border-2 border-rose-200 bg-white/80 text-rose-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-500/40 dark:bg-slate-900/60 dark:text-rose-200"
           size="lg"
         >
           <RotateCcw className="h-4 w-4 mr-2" />
@@ -185,7 +223,7 @@ export const QuizResults = ({
         </Button>
         <Button
           onClick={onBackToMenu}
-          className="flex-1"
+          className="flex-1 rounded-2xl bg-rose-500 text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-rose-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200"
           size="lg"
         >
           <ArrowRight className="h-4 w-4 mr-2" />

--- a/components/educa/matematicas/tablas/ui/TableExplorer.tsx
+++ b/components/educa/matematicas/tablas/ui/TableExplorer.tsx
@@ -28,30 +28,58 @@ export const TableExplorer = ({
   const [hoveredCell, setHoveredCell] = useState<string | null>(null);
 
   const tableNumbers = Array.from(
-    { length: maxTable - minTable + 1 }, 
+    { length: maxTable - minTable + 1 },
     (_, i) => minTable + i
   );
+
+  const gradientPalettes = [
+    'from-rose-200 via-rose-50 to-amber-100 dark:from-rose-900 dark:via-rose-800 dark:to-amber-900',
+    'from-sky-200 via-white to-emerald-200 dark:from-sky-900 dark:via-slate-900 dark:to-emerald-900',
+    'from-indigo-200 via-purple-100 to-sky-100 dark:from-indigo-900 dark:via-indigo-800 dark:to-sky-900',
+    'from-amber-200 via-orange-100 to-pink-200 dark:from-amber-900 dark:via-orange-900 dark:to-pink-900',
+    'from-emerald-200 via-teal-100 to-cyan-200 dark:from-emerald-900 dark:via-teal-900 dark:to-cyan-900',
+    'from-violet-200 via-fuchsia-100 to-rose-200 dark:from-violet-900 dark:via-fuchsia-900 dark:to-rose-900'
+  ];
 
   return (
     <div className="space-y-6">
       {/* Selector de tabla */}
-      <Panel title={i18n.selectTable}>
-        <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
-          {tableNumbers.map(num => (
-            <Button
-              key={num}
-              variant={selectedTable === num ? "default" : "outline"}
-              onClick={() => onTableSelect(num)}
-              className="aspect-square"
-            >
-              {num}
-            </Button>
-          ))}
+      <Panel
+        title={i18n.selectTable}
+        className="bg-gradient-to-br from-indigo-50 via-white to-sky-50 dark:from-slate-900 dark:via-slate-950 dark:to-indigo-950 border-0 shadow-xl"
+      >
+        <div className="grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-6 gap-4 justify-items-center">
+          {tableNumbers.map((num, index) => {
+            const gradient = gradientPalettes[index % gradientPalettes.length];
+            const isSelected = selectedTable === num;
+
+            return (
+              <Button
+                key={num}
+                variant="ghost"
+                onClick={() => onTableSelect(num)}
+                aria-pressed={isSelected}
+                className={cn(
+                  'h-20 w-20 rounded-full text-2xl font-bold text-slate-900 dark:text-white shadow-lg transition-transform duration-200 ease-out hover:-translate-y-1 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-indigo-500 focus-visible:ring-0 focus-visible:border-transparent hover:bg-transparent',
+                  'relative overflow-hidden bg-gradient-to-br backdrop-blur-sm',
+                  gradient,
+                  isSelected
+                    ? 'ring-4 ring-indigo-300 dark:ring-indigo-500 ring-offset-2 ring-offset-white dark:ring-offset-slate-950'
+                    : 'ring-1 ring-white/60 dark:ring-white/10'
+                )}
+              >
+                <span className="drop-shadow-[0_1px_1px_rgba(0,0,0,0.15)]">{num}</span>
+              </Button>
+            );
+          })}
         </div>
       </Panel>
 
       {/* Tabla de multiplicar */}
-      <Panel title={`Tabla del ${selectedTable}`}>
+      <Panel
+        title={`Tabla del ${selectedTable}`}
+        className="bg-white/80 dark:bg-slate-900/60 border-0 shadow-lg backdrop-blur"
+      >
         <div className="space-y-3">
           {Array.from({ length: 12 }, (_, i) => i + 1).map(multiplier => {
             const result = selectedTable * multiplier;
@@ -62,27 +90,40 @@ export const TableExplorer = ({
               <div
                 key={cellKey}
                 className={cn(
-                  "flex items-center justify-between p-3 rounded-lg border transition-all duration-200 cursor-pointer",
-                  isHovered 
-                    ? "bg-blue-50 border-blue-200 shadow-sm" 
-                    : "bg-gray-50 border-gray-200 hover:bg-gray-100"
+                  'flex items-center justify-between p-4 rounded-2xl border-2 transition-all duration-200 cursor-pointer bg-white/90 dark:bg-slate-900/70 shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400',
+                  isHovered
+                    ? 'border-indigo-200/70 bg-indigo-50/80 dark:border-indigo-500/40 dark:bg-indigo-950/60 shadow-md'
+                    : 'border-indigo-100/60 dark:border-slate-700/70 hover:border-indigo-200 hover:bg-indigo-50/60 dark:hover:bg-slate-800/70'
                 )}
                 onMouseEnter={() => setHoveredCell(cellKey)}
                 onMouseLeave={() => setHoveredCell(null)}
                 role="button"
                 tabIndex={0}
+                onFocus={() => setHoveredCell(cellKey)}
+                onBlur={() => setHoveredCell(null)}
                 aria-label={`${selectedTable} por ${multiplier} igual ${result}`}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    setHoveredCell(cellKey);
+                  }
+                }}
               >
                 <div className="flex items-center space-x-3">
-                  <span className="text-lg font-semibold text-gray-700">
+                  <span className="text-lg font-semibold text-slate-800 dark:text-slate-100">
                     {selectedTable} × {multiplier}
                   </span>
-                  <span className="text-lg text-gray-500">=</span>
+                  <span className="text-lg text-slate-500 dark:text-slate-300">=</span>
                 </div>
-                
-                <Badge 
+
+                <Badge
                   variant={isHovered ? "default" : "secondary"}
-                  className="text-lg font-bold px-3 py-1"
+                  className={cn(
+                    'text-lg font-bold px-4 py-1.5 shadow-sm transition-colors',
+                    isHovered
+                      ? 'bg-indigo-500/90 text-white'
+                      : 'bg-indigo-100/80 text-indigo-900 dark:bg-indigo-900/60 dark:text-indigo-100'
+                  )}
                 >
                   {result}
                 </Badge>


### PR DESCRIPTION
## Summary
- transform the table selector into large gradient badges with improved focus and hover states
- restyle practice settings, question card, quiz results, and progress overview with playful cards, chips, and accessible focus rings
- refine hint bubbles, breakdown cards, and progress summaries for better legibility across light and dark themes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3ad94cb08327a6849d53006cb1d4